### PR TITLE
Only apply brfs transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function babelBrfs (filename, opts) {
             onFile: this.emit.bind(this, 'file')
           } ]
         ],
+        babelrc: false,
         filename: filename
       });
       this.push(result.code);


### PR DESCRIPTION
This prevents babel.transform() from applying the whole Babelify transform (as specified in my .babelrc) in this transform.

I'll admit I'm not 100% sure how everything interacts, as my gulp stream is using babelify, browserify, watchify, gulp-sourcemaps, vinyl-source-stream, uglify, and now brfs-babel.  However, the result I was getting was the stream coming out of brfs-babel seemed to have a whole bunch of transforms applied (classes were converted to _createClass, etc), and was not outputting any sourcemaps, so it was producing code that didn't show up right in the Chrome debugger.  I'm guessing this babel.transform() is using the .babelrc I have defined for my actual (later) babelify transform, and when I add this option, it seems to behave correctly - my source looks right in Chrome, my file is getting embedded, and watchify is reloading things appropriately (which I couldn't get working with any other brfs implementation/plugin/transform).  I tried putting brfs-babel before or after my other transforms and it didn't seem to help (even after babelify, it was still applying some transform (or losing the sourcemap, or something) and causing the wrong code to show up in Chrome.